### PR TITLE
Potential fix for code scanning alert no. 19: Disabling certificate validation

### DIFF
--- a/src/Misc/layoutbin/checkScripts/downloadCert.js
+++ b/src/Misc/layoutbin/checkScripts/downloadCert.js
@@ -10,7 +10,6 @@ const proxyPort = process.env['PROXYPORT'] || ''
 const proxyUsername = process.env['PROXYUSERNAME'] || ''
 const proxyPassword = process.env['PROXYPASSWORD'] || ''
 
-process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0'
 
 if (proxyHost === '') {
     const options = {


### PR DESCRIPTION
Potential fix for [https://github.com/sanibrand-tech/runner/security/code-scanning/19](https://github.com/sanibrand-tech/runner/security/code-scanning/19)

To mitigate this vulnerability, certificate validation should *not* be disabled. This means removing or commenting out the line `process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0'`. By default, Node.js will reject unauthorized certificates, i.e., it will only permit connecting to servers with valid certificates. 

If the code *must* connect to a self-signed/test instance, the secure solution is to provide the trusted CA certificate explicitly for validation—*not* to disable validation outright. Since only the disabling line is shown, the best fix here is to delete/comment that line. No additional imports or supporting changes are strictly needed, but users wanting to connect to services with self-signed certificates should be instructed to configure the `ca` option when making requests (see Node.js documentation for `https.request`).

Thus, only line 13 needs to be removed or commented out in `src/Misc/layoutbin/checkScripts/downloadCert.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
